### PR TITLE
Document plugin location and workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,25 @@
 # AGENTS.md
 
-Guidance for AI agents (Codex/ChatGPT) working in the `tta-management-plugin` repository.
+Guidance for AI agents (Codex/ChatGPT) working in the Trying To Adult RVA repository.
 
 ---
 
 ## 🧰 Repository Overview
-- **Name:** `tta-management-plugin`
-- **Purpose:** A WordPress plugin for managing members, events, tickets, waitlists, notifications, and Authorize.Net payment integrations.
+- **Site:** Full WordPress site for Trying To Adult RVA.
+- **Primary Plugin:** `app/public/wp-content/plugins/tta-management-plugin`
+  - Unless a task explicitly states otherwise, assume all questions and changes relate to this plugin.
+  - The plugin must remain self‑contained so it can be copied to another WordPress installation and function on its own.
 
 ---
 
 ## 🧪 Development Environment
-- **PHP:** Codex must explicitly install PHP into its container before execution. Assume PHP is not pre-installed; explicitly install it each time.
-- **Composer:** Used for dependency management.
-- **PHPUnit:** Used for running tests.  
+- **PHP:** Explicitly install PHP in the container before running any PHP or Composer commands.
+- **Composer & PHPUnit:** Run from the plugin directory:
+  ```bash
+  cd app/public/wp-content/plugins/tta-management-plugin
+  composer install
+  vendor/bin/phpunit
+  ```
 - **WordPress:** Plugin runs in a WordPress environment; follow WP coding standards, hooks, actions, and filters.
 
 ---
@@ -52,6 +58,8 @@ Guidance for AI agents (Codex/ChatGPT) working in the `tta-management-plugin` re
 ## 🔄 Workflow & Processes
 
 ### Composer workflow
+Run Composer commands inside the plugin directory.
+
 ```bash
 composer install                        # Install dependencies
 composer update                         # Update dependencies and lock file

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # TTA Actual
-The Entire LIVE TTA Website & Plugin
+
+This repository contains the full WordPress site for **Trying To Adult RVA**.
+
+## Trying To Adult Management Plugin
+
+Most development work happens inside the plugin located at:
+
+`app/public/wp-content/plugins/tta-management-plugin`
+
+- Unless a task explicitly states otherwise, assume questions and changes refer to this plugin.
+- The plugin must remain self-contained so it can be copied to another WordPress installation and function on its own.
+
+## Development Notes
+
+Run Composer and PHPUnit from the plugin directory:
+
+```bash
+cd app/public/wp-content/plugins/tta-management-plugin
+composer install
+vendor/bin/phpunit
+```
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODOs
 
-A running list of tasks and reminders for future development.
+A running list of tasks and reminders for future development in the **Trying To Adult Management Plugin** (`app/public/wp-content/plugins/tta-management-plugin`).
 
 - [x] Test the scenario where cart items become unavailable mid-checkout and display a clear notice to users.
 - [ ] Create a referral program page (`/referral-program`) and implement a one-time referral discount code that can be applied to any event.

--- a/app/public/wp-content/plugins/tta-management-plugin/AGENTS.md
+++ b/app/public/wp-content/plugins/tta-management-plugin/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+Guidance for AI agents working on the **Trying To Adult Management Plugin**.
+
+## Scope
+- Path: `app/public/wp-content/plugins/tta-management-plugin`.
+- Unless a task explicitly states otherwise, treat all user requests as targeting this plugin.
+- Keep the plugin fully self‑contained so it can be dropped into any WordPress installation and function on its own.
+
+## Development
+- Run Composer and PHPUnit from this directory.
+- Update documentation and tests alongside any code changes.
+- Refer to the repository‑root `AGENTS.md` for caching, performance, security, and coding‑standard guidance.
+


### PR DESCRIPTION
## Summary
- note plugin path and self-contained requirement in root documentation
- add AGENTS file within plugin to direct future work
- clarify README and TODO with plugin-first guidance

## Testing
- `php -v`
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68a4e0e21ab883209a3ebaa46222f064